### PR TITLE
Mobile UI fix and add juse.js to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@ant-design/icons": "^4.0.2",
     "@seregpie/bron-kerbosch": "^1.0.0",
     "antd": "^4.0.2",
+    "fuse.js": "^6.3.1",
     "react-easy-state": "^6.1.3"
   }
 }

--- a/src/assets/scss/App.scss
+++ b/src/assets/scss/App.scss
@@ -120,7 +120,7 @@ body {
     position: relative;
     width: 100%;
     height: 88vh;
-    overflow: hidden;
+    overflow-x: hidden;
   }
 
   .ctrls {
@@ -129,5 +129,6 @@ body {
     left: 0px;
     top: 0px;
     width: 100%;
+    padding: 1em;
   }
 }


### PR DESCRIPTION
This pull request resolves 2 minor UI issues and a missing dependency that was forgotten to be added into the package.json

## Issue 1: Display timetable issue with screen size max-width of 700px
Resolves issue #1 for mobile users with a max-width of 700px. I have forgotten to take into account there was a media query that overruled the default style.

## Issue 2: Display of ant text input placeholder with ant button
Another issue that was detected was the text input placeholder for course code went over the dropdown button (ant-button).
[Here's an example of how it looks like](https://imgur.com/OFkrn4A)

## Issue 3: Missing fuse.js in package.js
When fetching the latest code, I encountered this issue:
```
ERROR in ./components/crsdb.tsx
Module not found: Error: Can't resolve 'fuse.js' in '/home/zaku/Downloads/test/TimerTable/src/components'
 @ ./components/crsdb.tsx 211:16-34
 @ ./components/App.tsx
 @ ./index.tsx
 @ multi react-hot-loader/patch webpack-dev-server/client?http://localhost:8080 webpack/hot/only-dev-server ./index.tsx
```
Therefore I added fuse.js to package.json so that any new developer and web hosters can avoid this issue.